### PR TITLE
chore: use canary flow from common

### DIFF
--- a/.github/workflows/run_canary.yaml
+++ b/.github/workflows/run_canary.yaml
@@ -13,4 +13,5 @@ jobs:
     secrets: inherit
     with:
       schema-type: "playerV3Versions"
+      node-version: "18.x"
       tests-yarn-run-to-execute: 'build eslint'


### PR DESCRIPTION
### Description of the Changes

Use canary flow from common instead of old canary flow

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
