### PR TITLE
fix(FEC-13931): Audio player| canary audio player version failed to load

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/runtime": "^7.23.8",
     "@microsoft/api-extractor": "^7.39.1",
     "@playkit-js/browserslist-config": "1.0.8",
-    "@playkit-js/kaltura-player-js": "3.17.15-canary.0-b412bfc",
+    "@playkit-js/kaltura-player-js": "3.17.15-canary.0-fbc614b",
     "@types/preact-i18n": "1.2.0",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,16 +14,12 @@ export {VERSION, NAME};
 const pluginName = 'audioPlayer';
 registerPlugin(pluginName, AudioPlayer);
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-
 const AudioPreset = {
   template: (): any => miniAudioUI({player: {}, config: {}}),
   condition: (): boolean => true
 };
 
 // the preset needs to be injected into the player config before the player ui is loaded
-window.__kalturaplayerdata = window.__kalturaplayerdata || {};
-window.__kalturaplayerdata.ui = window.__kalturaplayerdata.ui || {};
-window.__kalturaplayerdata.ui.customPreset = window.__kalturaplayerdata.ui.customPreset || [];
-window.__kalturaplayerdata.ui.customPreset.push(AudioPreset);
+window.kalturaCustomPreset = [AudioPreset];
+
+

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,2 +1,2 @@
 declare module '*.scss';
-declare var __kalturaplayerdata: any;
+declare var kalturaCustomPreset: any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,16 +1281,16 @@
     classnames "^2.3.2"
     linkify-it "^4.0.1"
 
-"@playkit-js/kaltura-player-js@3.17.15-canary.0-b412bfc":
-  version "3.17.15-canary.0-b412bfc"
-  resolved "https://registry.yarnpkg.com/@playkit-js/kaltura-player-js/-/kaltura-player-js-3.17.15-canary.0-b412bfc.tgz#7785fcaa89da71d81079e28d98fb3b4cbceba48d"
-  integrity sha512-iDXJD8+7YkB5S+8tYeRrJp/i5g/dhhbtXUF1b9dRjEeffFAB4ND1dwmeSTR8mPIhbCbrF4fJa0Yq/scHNV4EEA==
+"@playkit-js/kaltura-player-js@3.17.15-canary.0-fbc614b":
+  version "3.17.15-canary.0-fbc614b"
+  resolved "https://registry.yarnpkg.com/@playkit-js/kaltura-player-js/-/kaltura-player-js-3.17.15-canary.0-fbc614b.tgz#79d6bbd2b70a87759dbe44f529aede077864d0d6"
+  integrity sha512-KgLvPco6qYqn/02SMCHXdqrdu4kLOCn4hxw4ErVqG2T1gs5KrBey4AcUwjCkM/Of40Kp1CMS5xmpb+bOCJImxA==
   dependencies:
     "@playkit-js/playkit-js" "0.84.8"
     "@playkit-js/playkit-js-dash" "1.37.0"
     "@playkit-js/playkit-js-hls" "1.32.11"
     "@playkit-js/playkit-js-providers" "2.40.5"
-    "@playkit-js/playkit-js-ui" "0.79.0"
+    "@playkit-js/playkit-js-ui" "0.79.1-canary.0-75172c7"
     hls.js "^1.5.8"
     shaka-player "4.7.0"
 
@@ -1309,10 +1309,10 @@
   resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-providers/-/playkit-js-providers-2.40.5.tgz#7a336856778a315539f9ecf0343f9269c4ba29ab"
   integrity sha512-7Wny9y9KajDkk4y2FHEf7729TCXCeAfuseJGrQ8vLvteAYQ3A6U50ukkzB0nw7aoH/ZGqOldM0llZ7drnkHr9g==
 
-"@playkit-js/playkit-js-ui@0.79.0":
-  version "0.79.0"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-ui/-/playkit-js-ui-0.79.0.tgz#83b4d697fce5b2c352ccb9d881e85153b0b6c24a"
-  integrity sha512-u3ilnSkTfsk1vvJNt+slNOUHHkSU6gOTw65YiS5NkmmHKBiIzeFkhr/G3StIzlqkguseDvVd/psJOK36qbZ0Jw==
+"@playkit-js/playkit-js-ui@0.79.1-canary.0-75172c7":
+  version "0.79.1-canary.0-75172c7"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-ui/-/playkit-js-ui-0.79.1-canary.0-75172c7.tgz#4a1cc55e0b2c0c73b568c71eafd5a388a30cfa8a"
+  integrity sha512-lniyu1LFe+g1X6sFy0pEMm0udpejYnLiCOONWNuoEcOyPI4HVv9BX+8gUh+8HZrJUeuY38sVh5WUgyon3vAz3A==
   dependencies:
     preact "10.4.6"
     preact-i18n "2.0.0-preactx.2"


### PR DESCRIPTION
### Description of the Changes

**Issue:** the gloabal back-end var window.__kalturaplayerdata is declared after the player and plugins code in bundle file

**Fix:** set a dedicated var for custom preset

#### Resolves FEC-13931

#### Related PR
https://github.com/kaltura/kaltura-player-js/pull/771