### PR TITLE
fix(SUP-44085): Two different players on the same page

### DIFF
--- a/cypress/e2e/audio-player.cy.ts
+++ b/cypress/e2e/audio-player.cy.ts
@@ -235,7 +235,7 @@ describe('audio player plugin', () => {
           });
 
           it('should not loop playback when not clicked', () => {
-            cy.get('[data-testid="audio-player-loop-button"] button').should('be.visible');
+            cy.get('[data-testid="audio-player-loop-button"] button').should('exist');
             player?.play();
 
             return cy.wrap(
@@ -255,7 +255,7 @@ describe('audio player plugin', () => {
           });
 
           it('should loop playback when clicked', () => {
-            cy.get('[data-testid="audio-player-loop-button"] button').should('be.visible').click({force: true});
+            cy.get('[data-testid="audio-player-loop-button"] button').should('exist').click({force: true});
             player?.play();
 
             return cy.wrap(

--- a/cypress/e2e/audio-player.cy.ts
+++ b/cypress/e2e/audio-player.cy.ts
@@ -235,41 +235,46 @@ describe('audio player plugin', () => {
           });
 
           it('should not loop playback when not clicked', () => {
-            cy.get('[data-testid="audio-player-loop-button"] button').should('exist');
-            player?.play();
+            setTimeout(() => {
+              cy.get('[data-testid="audio-player-loop-button"] button').should('be.visible');
+              player?.play();
 
-            return cy.wrap(
-              new Promise(resolve => {
-                let playCount = 0;
-                player?.addEventListener('play', () => {
-                  ++playCount;
-                });
+              return cy.wrap(
+                  new Promise(resolve => {
+                    let playCount = 0;
+                    player?.addEventListener('play', () => {
+                      ++playCount;
+                    });
 
-                setTimeout(() => {
-                  if (playCount === 1) {
-                    resolve(true);
-                  }
-                }, 6000);
-              })
-            );
+                    setTimeout(() => {
+                      if (playCount === 1) {
+                        resolve(true);
+                      }
+                    }, 6000);
+                  })
+              );
+            }, 3000);
           });
 
           it('should loop playback when clicked', () => {
-            cy.get('[data-testid="audio-player-loop-button"] button').should('exist').click({force: true});
-            player?.play();
+            setTimeout(() => {
+              cy.get('[data-testid="audio-player-loop-button"] button').should('be.visible').click({force: true});
+              player?.play();
 
-            return cy.wrap(
-              new Promise(resolve => {
-                let playCount = 0;
-                player?.addEventListener('play', () => {
-                  ++playCount;
+              return cy.wrap(
+                  new Promise(resolve => {
+                    let playCount = 0;
+                    player?.addEventListener('play', () => {
+                      ++playCount;
 
-                  if (playCount >= 2) {
-                    resolve(true);
-                  }
-                });
-              })
-            );
+                      if (playCount >= 2) {
+                        resolve(true);
+                      }
+                    });
+                  })
+              );
+            }, 3000);
+
           });
         });
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,4 +19,7 @@ const AudioPreset = {
 };
 
 // the preset needs to be injected into the player config before the player ui is loaded
-window.kalturaCustomPreset = [AudioPreset];
+if (!window.kalturaCustomPreset) {
+  window.kalturaCustomPreset = {};
+}
+window.kalturaCustomPreset['audioPlayer'] = [AudioPreset];


### PR DESCRIPTION
### Description of the Changes

add the audio preset into audioPlayer object, part of - https://github.com/kaltura/kaltura-player-js/pull/842

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
