### PR TITLE
fix(SUP-44377): Embeds impact on page load

### DIFF
--- a/src/components/audio-player-view/audio-player-view.tsx
+++ b/src/components/audio-player-view/audio-player-view.tsx
@@ -1,5 +1,5 @@
 import {h, Fragment} from 'preact';
-import {useState, useEffect} from 'preact/hooks';
+import {useState, useEffect, useLayoutEffect} from 'preact/hooks';
 import {ui, core, KalturaPlayer} from '@playkit-js/kaltura-player-js';
 import {
   AudioPlayerControls,
@@ -123,10 +123,13 @@ const AudioPlayerView = Event.withEventManager(
           const pluginConfig: AudioPlayerConfig = player.plugins['audioPlayer'].config;
           const showMorePluginsIcon: boolean = availablePlugins.length > 0;
 
-          useEffect(() => {
-            addPlayerClass!();
+          useLayoutEffect(() => {
             eventManager.listen(player, core.EventType.CHANGE_SOURCE_ENDED, _handleMediaMetadata);
             eventManager.listen(player, core.EventType.PLAYER_RESET, _handleMediaMetadataReset);
+          }, []);
+
+          useEffect(() => {
+            addPlayerClass!();
             return () => {
               removePlayerClass!();
             };

--- a/src/components/audio-player-view/audio-player-view.tsx
+++ b/src/components/audio-player-view/audio-player-view.tsx
@@ -124,16 +124,13 @@ const AudioPlayerView = Event.withEventManager(
           const showMorePluginsIcon: boolean = availablePlugins.length > 0;
 
           useLayoutEffect(() => {
+            addPlayerClass!();
             eventManager.listen(player, core.EventType.CHANGE_SOURCE_ENDED, _handleMediaMetadata);
             eventManager.listen(player, core.EventType.PLAYER_RESET, _handleMediaMetadataReset);
-          }, []);
-
-          useEffect(() => {
-            addPlayerClass!();
             return () => {
               removePlayerClass!();
             };
-          }, []);
+            }, []);
 
           const _handleMediaMetadataReset = () => {
             setMediaMetadata(null);

--- a/src/components/audio-player-view/audio-player-view.tsx
+++ b/src/components/audio-player-view/audio-player-view.tsx
@@ -130,7 +130,7 @@ const AudioPlayerView = Event.withEventManager(
             return () => {
               removePlayerClass!();
             };
-            }, []);
+          }, []);
 
           const _handleMediaMetadataReset = () => {
             setMediaMetadata(null);


### PR DESCRIPTION
issue:
when there are lots of audio embeds sometimes there are several embed that stack on loading state.

current:
when the embeds not finished to load the listeners are happening after the event CHANGE_SOURCE_ENDED has thrown.

solution:
change the location of the listeners so they will run sooner and so when the event is thrown the listeners already called.

solved [SUP-44377](https://kaltura.atlassian.net/browse/SUP-44377)


[SUP-44377]: https://kaltura.atlassian.net/browse/SUP-44377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ