### PR TITLE
fix(SUP-45648): [UvA] responsiveness of v7 audio player

### DIFF
--- a/src/components/audio-player-view/audio-player-view.scss
+++ b/src/components/audio-player-view/audio-player-view.scss
@@ -13,7 +13,7 @@
 
     .top-controls {
       display: flex;
-      justify-content: space-between;
+      justify-content: center;
       height: calc(100% - 58px);
       padding: 8px 0;
 
@@ -38,7 +38,7 @@
     .right-controls {
       display: flex;
       flex-direction: column;
-      justify-content: space-between;
+      justify-content: center;
       width: calc(100% - 124px);
 
       .top-controls {
@@ -75,7 +75,7 @@
       z-index: 1;
       display: flex;
       flex-direction: column;
-      justify-content: space-between;
+      justify-content: center;
       width: calc(100% - 264px);
     }
   }


### PR DESCRIPTION
issue:
on kms when change the browser sizes the bottom bar might be cut off.

solution:
change the css justify-content value

solve [SUP-45648](https://kaltura.atlassian.net/browse/SUP-45648)


[SUP-45648]: https://kaltura.atlassian.net/browse/SUP-45648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ