### PR TITLE
fix(SUP-46053):Audio Player responsiveness - KAF and KMS

### DIFF
--- a/src/components/scrolling-text/scrolling-text.tsx
+++ b/src/components/scrolling-text/scrolling-text.tsx
@@ -57,6 +57,12 @@ const ScrollingTextComponent = ({
   const isHorisontal = mode === ScrollingTextModes.Horizontal;
 
   useEffect(() => {
+    if (maxHeight !== textContainerHeight && !(maxHeight === undefined && textContainerHeight === 'auto')){
+      setTextContainerHeight(maxHeight ?? 'auto');
+    }
+  }, [maxHeight]);
+
+  useEffect(() => {
     handleResize();
   }, []);
 
@@ -85,6 +91,9 @@ const ScrollingTextComponent = ({
     if (newTextSize && textSize !== newTextSize) {
       setTextSize(newTextSize);
     }
+    // if (maxHeight !== textContainerHeight){
+    //   setTextContainerHeight(maxHeight ?? 'auto');
+    // }
   };
 
   const handleMouseOver = () => {

--- a/src/components/scrolling-text/scrolling-text.tsx
+++ b/src/components/scrolling-text/scrolling-text.tsx
@@ -91,9 +91,6 @@ const ScrollingTextComponent = ({
     if (newTextSize && textSize !== newTextSize) {
       setTextSize(newTextSize);
     }
-    // if (maxHeight !== textContainerHeight){
-    //   setTextContainerHeight(maxHeight ?? 'auto');
-    // }
   };
 
   const handleMouseOver = () => {


### PR DESCRIPTION
### Description of the Changes

**Issue:**
sometimes when resize the page, the bottom bar with the controls is not shown.

**Solution:**
The issue happens because the title element get style of height. it's necessary only in large player, when user resize page and player size is medium, the height doesn't update sometimes.
We should check if maxHeight was changed (per the player size) then update the height value.

solves [SUP-46053](https://kaltura.atlassian.net/browse/SUP-46053)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-46053]: https://kaltura.atlassian.net/browse/SUP-46053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ