### PR TITLE
feat(FEC-14125): Player timeline sound visualization - product analytics

### DIFF
--- a/src/components/audio-player-view/audio-player-view.tsx
+++ b/src/components/audio-player-view/audio-player-view.tsx
@@ -1,6 +1,8 @@
 import {h, Fragment} from 'preact';
 import {useState, useEffect, useLayoutEffect} from 'preact/hooks';
 import {ui, core, KalturaPlayer} from '@playkit-js/kaltura-player-js';
+import {FakeEvent} from '@playkit-js/playkit-js';
+import {AUDIO_PLAYER_VISUALIZATION_STATE} from '../../events/events';
 import {
   AudioPlayerControls,
   VolumeMapSeekbar,
@@ -199,6 +201,13 @@ const AudioPlayerView = Event.withEventManager(
         };
 
         const _renderView = () => {
+          // event to notify about visualization state
+          player.dispatchEvent(
+            new FakeEvent(AUDIO_PLAYER_VISUALIZATION_STATE, {
+              state: pluginConfig.useVolumeMapBar ? 'enabled' : 'disabled',
+              size: size
+            })
+          );
           if (size === AudioPlayerSizes.Small) {
             return (
               !overlayOpen && (

--- a/src/components/audio-player-view/audio-player-view.tsx
+++ b/src/components/audio-player-view/audio-player-view.tsx
@@ -205,7 +205,7 @@ const AudioPlayerView = Event.withEventManager(
           player.dispatchEvent(
             new FakeEvent(AUDIO_PLAYER_VISUALIZATION_STATE, {
               state: pluginConfig.useVolumeMapBar ? 'enabled' : 'disabled',
-              size: size
+              size
             })
           );
           if (size === AudioPlayerSizes.Small) {

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -1,1 +1,2 @@
 export const AUDIO_PLAYER_ACTIVE_PLUGINS_UPDATED = 'audio_player_active_plugins_updated';
+export const AUDIO_PLAYER_VISUALIZATION_STATE = 'audio_player_visualization_state';


### PR DESCRIPTION
- Add a new event `AUDIO_PLAYER_VISUALIZATION_STATE` to notify about the audio visualization state.
- Dispatches the visualization state event from `AudioPlayerView`, indicating if the volume map bar is enabled or disabled and includes the current player size.

Related PR: https://github.com/kaltura/playkit-js-kava/pull/205

[FEC-14125](https://kaltura.atlassian.net/browse/FEC-14125)

[FEC-14125]: https://kaltura.atlassian.net/browse/FEC-14125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ